### PR TITLE
Add Ollama LLM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ build/
 .env
 .venv/
 venv/
+
+# Claude Code files
+CLAUDE.md

--- a/rag-update-demo.py
+++ b/rag-update-demo.py
@@ -531,8 +531,14 @@ class ProductKnowledgeManager:
             }
             self._save_product_relationships()
         
-        # Persist the vector store to disk
-        self.vectorstore.persist()
+        # Persist the vector store to disk if the method exists
+        try:
+            if hasattr(self.vectorstore, "persist") and callable(getattr(self.vectorstore, "persist")):
+                self.vectorstore.persist()
+            else:
+                logger.info("No persist method found on vectorstore - newer Chroma versions persist automatically")
+        except Exception as e:
+            logger.warning(f"Error persisting vector store: {str(e)} - continuing anyway")
         
         return len(ids)
     
@@ -627,8 +633,14 @@ class ProductKnowledgeManager:
                 "updated_documents": updated_count
             }
         
-        # Persist changes
-        self.vectorstore.persist()
+        # Persist changes if the method exists
+        try:
+            if hasattr(self.vectorstore, "persist") and callable(getattr(self.vectorstore, "persist")):
+                self.vectorstore.persist()
+            else:
+                logger.info("No persist method found on vectorstore - newer Chroma versions persist automatically")
+        except Exception as e:
+            logger.warning(f"Error persisting vector store: {str(e)} - continuing anyway")
         
         return result
 

--- a/rag-update-demo.py
+++ b/rag-update-demo.py
@@ -14,9 +14,12 @@ Requirements:
 - langchain-core
 - langchain-community
 - langchain-text-splitters
-- langchain-chroma
 - chromadb (or other vector store)
 - requests (for Ollama API)
+
+Note: This code may generate a deprecation warning about Chroma.
+To fix it permanently, install the langchain-chroma package and
+update the import to: from langchain_chroma import Chroma
 
 One of the following is required for LLM functionality:
 - langchain-openai and valid OPENAI_API_KEY (for OpenAI LLM and embeddings)
@@ -35,7 +38,8 @@ from typing import List, Dict, Any, Optional, Tuple
 
 # Vector database and embedding dependencies
 from langchain_openai import OpenAIEmbeddings
-from langchain_chroma import Chroma  # Updated import for Chroma
+# Keep using community version for now - proper fix requires installing langchain-chroma package
+from langchain_community.vectorstores import Chroma
 from langchain_core.documents import Document
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_community.document_loaders import TextLoader, PyPDFLoader, DirectoryLoader

--- a/rag-update-demo.py
+++ b/rag-update-demo.py
@@ -1031,11 +1031,52 @@ def run_product_replacement_demo():
     print("\nDemo complete!")
 
 
+def print_debug_info():
+    """Print debugging information to help diagnose issues."""
+    print("\n=== Debug Information ===")
+    
+    # Check OpenAI API key
+    if "OPENAI_API_KEY" in os.environ:
+        key = os.environ["OPENAI_API_KEY"]
+        # Only show the first 5 and last 5 characters of the key
+        if len(key) > 12:
+            masked_key = f"{key[:5]}...{key[-5:]}"
+        else:
+            masked_key = "***SET BUT TOO SHORT***"
+        print(f"OPENAI_API_KEY: {masked_key} (length: {len(key)})")
+    else:
+        print("OPENAI_API_KEY=unset")
+    
+    # Check Ollama availability
+    try:
+        response = requests.get(f"{LLMConfig.OLLAMA_BASE_URL}/api/tags", timeout=2)
+        print(f"Ollama Status: Available (HTTP {response.status_code})")
+        try:
+            models = response.json().get("models", [])
+            if models:
+                model_names = [model.get("name") for model in models]
+                print(f"Ollama Models: {', '.join(model_names)}")
+            else:
+                print("Ollama Models: None found")
+        except Exception:
+            print("Ollama Models: Error parsing response")
+    except Exception as e:
+        print(f"Ollama Status: Not available ({str(e)})")
+    
+    print("========================")
+
 if __name__ == "__main__":
     try:
+        # Print debug info at the start
+        print_debug_info()
+        
+        # Run the demo
         run_product_replacement_demo()
     except Exception as e:
         logger.error(f"Error: {str(e)}")
+        
+        # Print debug info again on error
+        print_debug_info()
         
         error_msg = str(e).lower()
         if "quota" in error_msg or "insufficient_quota" in error_msg or "429" in error_msg:

--- a/rag-update-demo.py
+++ b/rag-update-demo.py
@@ -14,6 +14,7 @@ Requirements:
 - langchain-core
 - langchain-community
 - langchain-text-splitters
+- langchain-chroma
 - chromadb (or other vector store)
 - requests (for Ollama API)
 
@@ -34,7 +35,7 @@ from typing import List, Dict, Any, Optional, Tuple
 
 # Vector database and embedding dependencies
 from langchain_openai import OpenAIEmbeddings
-from langchain_community.vectorstores import Chroma
+from langchain_chroma import Chroma  # Updated import for Chroma
 from langchain_core.documents import Document
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_community.document_loaders import TextLoader, PyPDFLoader, DirectoryLoader


### PR DESCRIPTION
## Summary
- Added support for Ollama LLMs in rag-update-demo.py
- Created provider selection logic that tries OpenAI → Ollama → mock LLM
- Implemented the same provider architecture used in openai-rag-chat.py
- Added .gitignore entry for CLAUDE.md

## Test plan
- Run the demo with OpenAI API key set to test OpenAI integration
- Run the demo with Ollama running locally to test Ollama integration
- Run the demo with neither available to test fallback to mock LLM

🤖 Generated with [Claude Code](https://claude.ai/code)